### PR TITLE
`package.json`の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "pmx",
+  "main": "pmx.js",
+  "version": "0.0.0",
+  "private": true,
+
+  "description": "pmx - a pure JavaScript Parser for PMX Format(MMD)",
+  "scripts": {
+    "test": "node test_parse.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/59naga/pmx.git"
+  },
+  "keywords": [
+    "Vocaloid",
+    "VPVP",
+    "MikuMikuDance",
+    "MMD",
+    "PMX"
+  ],
+  "author": "KATO Kanryu <k.kanryu@gmail.com>",
+  "license": "Apache License 2",
+  "bugs": {
+    "url": "https://github.com/59naga/pmx/issues"
+  },
+  "homepage": "https://github.com/59naga/pmx#readme"
+}


### PR DESCRIPTION
お借りします。
`npm install https://github.com/kanryu/pmx.git`経由で使用する場合、`package.json`が無いエラーが出るため、それを修正するためのプルリクエストです。

``` bash

> npm i https://github.com/kanryu/pmx.git
npm ERR! addLocal Could not install /var/folders/kr/tr9txzzd3rsbq0ydlhqpjf2c0000gn/T/npm-85616-1cd96994/git-cache-474ee70105abfa06c35fe379360af2a8/6406b244a1121468e598a4c224dbf3b72703786f
npm ERR! Darwin 15.0.0
npm ERR! argv "node" "/usr/local/bin/npm" "i" "https://github.com/kanryu/pmx.git"
npm ERR! node v0.12.2
npm ERR! npm  v3.3.5
npm ERR! code EISDIR
npm ERR! errno -21

npm ERR! eisdir EISDIR, read
npm ERR! eisdir This is most likely not a problem with npm itself
npm ERR! eisdir and is related to npm not being able to find a package.json in
npm ERR! eisdir a package you are trying to install.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/59naga/Downloads/vpvp-threejs/npm-debug.log
```
